### PR TITLE
MPRAM: Add byte enable support for REG and XOR types

### DIFF
--- a/dpram_be.v
+++ b/dpram_be.v
@@ -1,0 +1,90 @@
+////////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2013, University of British Columbia (UBC); All rights reserved. //
+//                                                                                //
+// Redistribution  and  use  in  source   and  binary  forms,   with  or  without //
+// modification,  are permitted  provided that  the following conditions are met: //
+//   * Redistributions   of  source   code  must  retain   the   above  copyright //
+//     notice,  this   list   of   conditions   and   the  following  disclaimer. //
+//   * Redistributions  in  binary  form  must  reproduce  the  above   copyright //
+//     notice, this  list  of  conditions  and the  following  disclaimer in  the //
+//     documentation and/or  other  materials  provided  with  the  distribution. //
+//   * Neither the name of the University of British Columbia (UBC) nor the names //
+//     of   its   contributors  may  be  used  to  endorse  or   promote products //
+//     derived from  this  software without  specific  prior  written permission. //
+//                                                                                //
+// THIS  SOFTWARE IS  PROVIDED  BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" //
+// AND  ANY EXPRESS  OR IMPLIED WARRANTIES,  INCLUDING,  BUT NOT LIMITED TO,  THE //
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE //
+// DISCLAIMED.  IN NO  EVENT SHALL University of British Columbia (UBC) BE LIABLE //
+// FOR ANY DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY, OR CONSEQUENTIAL //
+// DAMAGES  (INCLUDING,  BUT NOT LIMITED TO,  PROCUREMENT OF  SUBSTITUTE GOODS OR //
+// SERVICES;  LOSS OF USE,  DATA,  OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER //
+// CAUSED AND ON ANY THEORY OF LIABILITY,  WHETHER IN CONTRACT, STRICT LIABILITY, //
+// OR TORT  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE //
+// OF  THIS SOFTWARE,  EVEN  IF  ADVISED  OF  THE  POSSIBILITY  OF  SUCH  DAMAGE. //
+////////////////////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////////
+//dpram.v: Generic dual-ported RAM with optional single-stage or two-stage bypass.//
+//                                                                                //
+//    Author: Ameer M. Abdelhadi (ameer@ece.ubc.ca, ameer.abdelhadi@gmail.com)    //
+// SRAM-based Multi-ported RAMs; University of British Columbia (UBC), March 2013 //
+////////////////////////////////////////////////////////////////////////////////////
+
+`include "utils.vh"
+
+module dpram_be
+ #(  parameter MEMD    = 16, // memory depth
+     parameter DATAW   = 32, // data width
+     parameter BYPASS  = 1 , // bypass? 0:none; 1: single-stage; 2: two-stage
+     parameter IZERO   = 0 , // binary / Initial RAM with zeros (has priority over IFILE)
+     parameter IFILE   = ""  // initialization hex file (don't pass extension), optional
+  )( input                    clk  , // clock
+     input                    WEnb , // write enable for each writing port
+     input  [`log2(MEMD)-1:0] WAddr, // write addresses - packed from nWPORTS write ports
+     input  [(DATAW/8)  -1:0] WBe,
+     input  [DATAW      -1:0] WData, // write data      - packed from nRPORTS read ports
+     input  [`log2(MEMD)-1:0] RAddr, // read  addresses - packed from nRPORTS  read  ports
+     output reg [DATAW  -1:0] RData  // read  data      - packed from nRPORTS read ports
+  );
+
+  wire [DATAW-1:0] RData_i; // read ram data (internal) - packed from nRPORTS read ports
+  mpram_gen_be #( .MEMD   (MEMD   ),  // memory depth
+               .DATAW  (DATAW  ),  // data width
+               .nRPORTS(1      ),  // number of reading ports
+               .nWPORTS(1      ),  // number of writing ports
+               .IZERO  (IZERO  ),  // binary / Initial RAM with zeros (has priority over INITFILE)
+               .IFILE  (IFILE  ))  // initializtion file, optional
+  dpram_inst ( .clk    (clk    ),  // clock
+               .WEnb   (WEnb   ),  // write enable for each writing port                - in : [nWPORTS-1:0            ]
+               .WAddr  (WAddr  ),  // write addresses - packed from nWPORTS write ports - in : [`log2(MEMD)*nWPORTS-1:0]
+               .WBe    (WBe    ),
+               .WData  (WData  ),  // write data      - packed from nRPORTS read  ports - out: [DATAW      *nWPORTS-1:0]
+               .RAddr  (RAddr  ),  // read  addresses - packed from nRPORTS read  ports - in : [`log2(MEMD)*nRPORTS-1:0]
+               .RData  (RData_i)); // read  data      - packed from nRPORTS read  ports - out: [DATAW      *nRPORTS-1:0]
+
+  // registers; will be removed if unused
+  reg WEnb_r;
+  reg [`log2(MEMD)-1:0] WAddr_r;
+  reg [`log2(MEMD)-1:0] RAddr_r;
+  reg [DATAW-1:0] WData_r;
+  always @(posedge clk) begin
+    WEnb_r  <= WEnb ;
+    WAddr_r <= WAddr;
+    RAddr_r <= RAddr;
+    WData_r <= WData; // bypass register
+  end
+  
+  // bypass: single-staeg, two-stage (logic will be removed if unused)
+  wire bypass1,bypass2;
+  assign bypass1 = (BYPASS >= 1) && WEnb_r && (WAddr_r == RAddr_r);
+  assign bypass2 = (BYPASS == 2) && WEnb   && (WAddr   == RAddr_r);
+
+  // output mux (mux or mux inputs will be removed if unused)
+  // FIXME
+  always @*
+    if (bypass2)      RData = WData  ;
+    else if (bypass1) RData = WData_r;
+         else         RData = RData_i;
+
+endmodule

--- a/mpram_gen_be.v
+++ b/mpram_gen_be.v
@@ -1,0 +1,93 @@
+////////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2013, University of British Columbia (UBC); All rights reserved. //
+//                                                                                //
+// Redistribution  and  use  in  source   and  binary  forms,   with  or  without //
+// modification,  are permitted  provided that  the following conditions are met: //
+//   * Redistributions   of  source   code  must  retain   the   above  copyright //
+//     notice,  this   list   of   conditions   and   the  following  disclaimer. //
+//   * Redistributions  in  binary  form  must  reproduce  the  above   copyright //
+//     notice, this  list  of  conditions  and the  following  disclaimer in  the //
+//     documentation and/or  other  materials  provided  with  the  distribution. //
+//   * Neither the name of the University of British Columbia (UBC) nor the names //
+//     of   its   contributors  may  be  used  to  endorse  or   promote products //
+//     derived from  this  software without  specific  prior  written permission. //
+//                                                                                //
+// THIS  SOFTWARE IS  PROVIDED  BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" //
+// AND  ANY EXPRESS  OR IMPLIED WARRANTIES,  INCLUDING,  BUT NOT LIMITED TO,  THE //
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE //
+// DISCLAIMED.  IN NO  EVENT SHALL University of British Columbia (UBC) BE LIABLE //
+// FOR ANY DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY, OR CONSEQUENTIAL //
+// DAMAGES  (INCLUDING,  BUT NOT LIMITED TO,  PROCUREMENT OF  SUBSTITUTE GOODS OR //
+// SERVICES;  LOSS OF USE,  DATA,  OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER //
+// CAUSED AND ON ANY THEORY OF LIABILITY,  WHETHER IN CONTRACT, STRICT LIABILITY, //
+// OR TORT  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE //
+// OF  THIS SOFTWARE,  EVEN  IF  ADVISED  OF  THE  POSSIBILITY  OF  SUCH  DAMAGE. //
+////////////////////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////////
+//   mpram_gen.v: Generic multiported-RAM; Old data will be read in case of RAW.  //
+//                                                                                //
+//    Author: Ameer M. Abdelhadi (ameer@ece.ubc.ca, ameer.abdelhadi@gmail.com)    //
+// SRAM-based Multi-ported RAMs; University of British Columbia (UBC), March 2013 //
+////////////////////////////////////////////////////////////////////////////////////
+
+`include "utils.vh"
+
+(* keep_hierarchy = "yes" *) module mpram_gen_be
+ #(  parameter MEMD    = 16, // memory depth
+     parameter DATAW   = 32, // data width
+     parameter nRPORTS = 3 , // number of reading ports
+     parameter nWPORTS = 2 , // number of writing ports
+     parameter IZERO   = 0 , // binary / Initial RAM with zeros (has priority over INITFILE)
+     parameter IFILE   = ""  // initialization hex file (don't pass extension), optional
+  )( input                                clk  , // clock
+     input      [nWPORTS-1:0            ] WEnb , // write enable for each writing port
+     input      [`log2(MEMD)*nWPORTS-1:0] WAddr, // write addresses - packed from nWPORTS write ports
+     input      [(DATAW/8)  *nWPORTS-1:0] WBe,
+     input      [DATAW      *nWPORTS-1:0] WData, // write data      - packed from nRPORTS read ports
+     input      [`log2(MEMD)*nRPORTS-1:0] RAddr, // read  addresses - packed from nRPORTS  read  ports
+     output reg [DATAW      *nRPORTS-1:0] RData  // read  data      - packed from nRPORTS read ports
+  );
+
+  localparam ADDRW = `log2(MEMD); // address width
+  integer i, j;
+
+  reg  [ADDRW        -1:0] WAddr2D  [nWPORTS-1:0];
+  reg  [(DATAW/8)    -1:0] WBe2D    [nWPORTS-1:0];
+  reg  [DATAW        -1:0] WData2D  [nWPORTS-1:0];
+  reg  [ADDRW        -1:0] RAddr2D  [nWPORTS-1:0];
+  reg  [DATAW        -1:0] RData2D  [nRPORTS-1:0];
+
+  `ARRINIT;
+  always @* begin
+    `ARR1D2D(nWPORTS,        ADDRW,WAddr   ,WAddr2D );
+    `ARR1D2D(nWPORTS,      DATAW/8,WBe     ,WBe2D   );
+    `ARR1D2D(nWPORTS,        DATAW,WData   ,WData2D );
+    `ARR1D2D(nWPORTS,        ADDRW,RAddr   ,RAddr2D );
+    `ARR2D1D(nRPORTS,        DATAW,RData2D ,RData   );
+  end
+
+  // initialize RAM, with zeros if IZERO or file if IFLE.
+  reg [DATAW-1:0] mem [0:MEMD-1]; // memory array
+  initial
+    if (IZERO)
+      for (i=0; i<MEMD; i=i+1) mem[i] = {DATAW{1'b0}};
+    else
+      if (IFILE != "") $readmemh({IFILE,".hex"}, mem);
+
+  always @(posedge clk) begin
+      // write to nWPORTS ports; nonblocking statement to read old data
+      for (i=0; i<nWPORTS; i=i+1) begin
+        for (j=0; j<DATAW/8; j=j+1) begin
+          if (WEnb[i] && WBe2D[i][j]) begin
+            mem[WAddr2D[i]][j*8 +: 8] <= WData2D[i][j*8 +: 8]; // Change into blocking statement (=) to read new data
+          end
+        end
+      end
+      // Read from nRPORTS ports; nonblocking statement to read old data
+      for (i=0; i<nRPORTS; i=i+1) begin
+        RData2D[i] <= mem[RAddr2D[i]]; //Change into blocking statement (=) to read new data
+      end
+    end
+
+endmodule

--- a/mrram_be.v
+++ b/mrram_be.v
@@ -1,0 +1,85 @@
+////////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2013, University of British Columbia (UBC); All rights reserved. //
+//                                                                                //
+// Redistribution  and  use  in  source   and  binary  forms,   with  or  without //
+// modification,  are permitted  provided that  the following conditions are met: //
+//   * Redistributions   of  source   code  must  retain   the   above  copyright //
+//     notice,  this   list   of   conditions   and   the  following  disclaimer. //
+//   * Redistributions  in  binary  form  must  reproduce  the  above   copyright //
+//     notice, this  list  of  conditions  and the  following  disclaimer in  the //
+//     documentation and/or  other  materials  provided  with  the  distribution. //
+//   * Neither the name of the University of British Columbia (UBC) nor the names //
+//     of   its   contributors  may  be  used  to  endorse  or   promote products //
+//     derived from  this  software without  specific  prior  written permission. //
+//                                                                                //
+// THIS  SOFTWARE IS  PROVIDED  BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" //
+// AND  ANY EXPRESS  OR IMPLIED WARRANTIES,  INCLUDING,  BUT NOT LIMITED TO,  THE //
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE //
+// DISCLAIMED.  IN NO  EVENT SHALL University of British Columbia (UBC) BE LIABLE //
+// FOR ANY DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY, OR CONSEQUENTIAL //
+// DAMAGES  (INCLUDING,  BUT NOT LIMITED TO,  PROCUREMENT OF  SUBSTITUTE GOODS OR //
+// SERVICES;  LOSS OF USE,  DATA,  OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER //
+// CAUSED AND ON ANY THEORY OF LIABILITY,  WHETHER IN CONTRACT, STRICT LIABILITY, //
+// OR TORT  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE //
+// OF  THIS SOFTWARE,  EVEN  IF  ADVISED  OF  THE  POSSIBILITY  OF  SUCH  DAMAGE. //
+////////////////////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////////
+// mrram.v:Multiread-RAM using bank replication; based on generic dual-ported RAM //
+//                 with optional single-stage or two-stage bypass                 //
+//                                                                                //
+//    Author: Ameer M. Abdelhadi (ameer@ece.ubc.ca, ameer.abdelhadi@gmail.com)    //
+// SRAM-based Multi-ported RAMs; University of British Columbia (UBC), March 2013 //
+////////////////////////////////////////////////////////////////////////////////////
+
+`include "utils.vh"
+
+module mrram_be
+ #(  parameter MEMD    = 16, // memory depth
+     parameter DATAW   = 32, // data width
+     parameter nRPORTS = 3 , // number of reading ports
+     parameter BYPASS  = 1 , // bypass? 0:none; 1: single-stage; 2:two-stages
+     parameter IZERO   = 0 , // binary / Initial RAM with zeros (has priority over IFILE)
+     parameter IFILE   = ""  // initialization mif file (don't pass extension), optional
+  )( input                                clk  ,  // clock
+     input                                WEnb ,  // write enable  (1 port)
+     input      [`log2(MEMD)        -1:0] WAddr,  // write address (1 port)
+     input      [(DATAW/8)          -1:0] WBe  ,
+     input      [DATAW              -1:0] WData,  // write data    (1 port)
+     input      [`log2(MEMD)*nRPORTS-1:0] RAddr,  // read  addresses - packed from nRPORTS  read  ports
+     output reg [DATAW      *nRPORTS-1:0] RData); // read  data - packed from nRPORTS read ports
+
+  localparam ADDRW = `log2(MEMD); // address width
+
+  // unpacked read addresses/data
+  reg  [ADDRW-1:0] RAddr_upk [nRPORTS-1:0]; // read addresses - unpacked 2D array 
+  wire [DATAW-1:0] RData_upk [nRPORTS-1:0]; // read data      - unpacked 2D array 
+
+  // unpack read addresses; pack read data
+  `ARRINIT;
+  always @* begin
+    `ARR1D2D(nRPORTS,ADDRW,RAddr,RAddr_upk);
+    `ARR2D1D(nRPORTS,DATAW,RData_upk,RData);
+  end
+
+  // generate and instantiate generic RAM blocks
+  genvar rpi;
+  generate
+    for (rpi=0 ; rpi<nRPORTS ; rpi=rpi+1) begin: RPORTrpi
+      // generic dual-ported ram instantiation
+      dpram_be#(.MEMD   (MEMD        ),  // memory depth
+                .DATAW  (DATAW       ),  // data width
+                .BYPASS (BYPASS      ),  // bypass? 0: none; 1: single-stage; 2:two-stages
+                .IZERO  (IZERO       ),  // binary / Initial RAM with zeros (has priority over INITFILE)
+                .IFILE  (IFILE       ))  // initialization file, optional
+      dpram_i ( .clk  (clk           ),  // clock         - in
+                .WEnb (WEnb          ),  // write enable  - in
+                .WAddr(WAddr         ),  // write address - in : [`log2(MEMD)-1:0]
+                .WBe  (WBe           ), 
+                .WData(WData         ),  // write data    - in : [DATAW      -1:0]
+                .RAddr(RAddr_upk[rpi]),  // read  address - in : [`log2(MEMD)-1:0]
+                .RData(RData_upk[rpi])); // read  data    - out: [DATAW      -1:0]
+    end
+  endgenerate
+
+endmodule


### PR DESCRIPTION
I use the multiported ram for a vector register file where I realize a byte enable signal could be of use. In this commit, I add it to REG and XOR types of the multiported ram. LVT types are not updated with the byte enable signal as they require further changes of the design.